### PR TITLE
Allow local tests to access insecure localhost HTTPS

### DIFF
--- a/grunt/karma.yml
+++ b/grunt/karma.yml
@@ -1,12 +1,22 @@
 options:
   configFile: "test/karma.conf.js"
+  customLaunchers:
+    # Possible args https://peter.sh/experiments/chromium-command-line-switches/#allow-insecure-localhost
+    MyChrome:
+      base: "Chrome"
+      flags:
+        - "--allow-insecure-localhost"
+    MyChromium:
+      base: "Chromium"
+      flags:
+        - "--allow-insecure-localhost"
 
 chrome:
   browsers:
-    - Chrome
+    - MyChrome
 chromium:
   browsers:
-    - Chromium
+    - MyChromium
 firefox:
   browsers:
     - Firefox


### PR DESCRIPTION
Now there won't be a prompt or something asking the user to be sure
 about the certificate.
 Bitch, I'm developing this shit. I'm pretty damn sure I wanna access it!

LoveIsGrief/videojs-externals#23 Support HTTPS in Chrome and Chromium tests