### PR TITLE
Starting the player without a source locks up the interface

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -35,6 +35,7 @@
     // jasmine
     "jasmine",
     "expect",
+    "fail",
     "spyOn",
     "describe",
     "it",

--- a/src/tech/Soundcloud.js
+++ b/src/tech/Soundcloud.js
@@ -105,7 +105,9 @@ class Soundcloud extends Externals {
         break;
 
       case SC.Widget.Events.ERROR:
-        this.onPlayerError();
+        if(this.src_){
+          this.onPlayerError();
+        }
         break;
     }
   }

--- a/test/unit/base/generators/TestSuiteGenerator.js
+++ b/test/unit/base/generators/TestSuiteGenerator.js
@@ -217,6 +217,9 @@ export default class TestSuiteGenerator {
   _generateWidgetPlayerTest() {
     const iframeSourceTest = this.basicConfiguration.iframeSourceTest;
     return function (done) {
+      this.player.on('error', (error) => {
+        fail(error)
+      })
       this.player.ready(() => {
         var iframe = document.getElementsByTagName('iframe')[0];
         expect(iframe).toBeTruthy();


### PR DESCRIPTION
Seems like the issue was only with the Soundcloud external

Related to #31 